### PR TITLE
return null from getAgentPoolId, not -1

### DIFF
--- a/plugin-digitalocean-agent/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanPropertiesPatcher.java
+++ b/plugin-digitalocean-agent/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanPropertiesPatcher.java
@@ -48,6 +48,11 @@ public class DigitalOceanPropertiesPatcher {
     final String imageId = myConfig.getConfigurationParameters().get(BuildAgentConfigurationConstants.IMAGE_ID_PARAM_NAME);
     final String ipAddress = getIpAddress();
 
+    if (imageId == null) {
+      LOG.info(BuildAgentConfigurationConstants.IMAGE_ID_PARAM_NAME + " not set; assumming not running on Digital Ocean");
+      return;
+    }
+
     myConfig.setName(NamesFactory.getBuildAgentName(imageId, ipAddress));
     myConfig.addConfigurationParameter(BuildAgentConfigurationConstants.INSTANCE_ID_PARAM_NAME,
             NamesFactory.getInstanceId(ipAddress));

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
@@ -93,8 +93,7 @@ public class DigitalOceanCloudImage implements CloudImage {
   @Nullable
   @Override
   public Integer getAgentPoolId() {
-    //FIXME: Implement new method
-    return -1;
+    return null;
   }
 
   @Nullable

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudImage.java
@@ -136,6 +136,26 @@ public class DigitalOceanCloudImage implements CloudImage {
     return newInstance;
   }
 
+  public synchronized void addExistingDroplet(Droplet droplet, ExecutorService executor) {
+    int sshKeyId = 0; // dummy key, since the instance is already created
+    String regionId = droplet.getRegion().getSlug();
+    String sizeId = droplet.getSize();
+    final DigitalOceanCloudInstance instance = new DigitalOceanCloudInstance(
+      myApi, this, executor, sshKeyId, regionId, sizeId);
+    instance.setExistingDroplet(droplet);
+    final DigitalOceanCloudImage self = this;
+    instance.addOnDropletReadyListener(new DropletLifecycleListener() {
+      public void onDropletStarted(Droplet droplet) {}
+      public void onDropletError(Droplet droplet) {}
+      public void onDropletDestroyed(Droplet droplet) {
+        synchronized (self) {
+          myInstances.remove(instance.getInstanceId());
+        }
+      }
+    });
+    myInstances.put(instance.getInstanceId(), instance);
+  }
+
   public synchronized boolean canStartNewInstance() {
     return (myStartingInstances.size() + myInstances.size()) < myInstancesLimit;
   }

--- a/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudInstance.java
+++ b/plugin-digitalocean-server/src/main/java/com/cloudcastlegroup/digitaloceanplugin/DigitalOceanCloudInstance.java
@@ -141,6 +141,11 @@ public class DigitalOceanCloudInstance implements CloudInstance {
     return myErrorInfo;
   }
 
+  public void setExistingDroplet(Droplet droplet) {
+    myDroplet = droplet;
+    myStatus = InstanceStatus.RUNNING;
+  }
+
   /**
    * Check whether or not specified agent is running on this machine
    *


### PR DESCRIPTION
From https://confluence.jetbrains.com/display/TCD10/Open+API+Changes:

jetbrains.buildServer.clouds.CloudImage has new method Integer
getAgentPoolId() - it represents the agent pool that instances from
this image will fall into. The value is nullable, which means that agent
pool for the instances can be configured manually in Agents->Pools UI.